### PR TITLE
feat(runtime): stable predict() API for coinTrader2.0

### DIFF
--- a/src/cointrainer/registry.py
+++ b/src/cointrainer/registry.py
@@ -6,6 +6,7 @@ import logging
 import os
 import tempfile
 from datetime import datetime
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 import joblib
@@ -131,3 +132,16 @@ class ModelRegistry:
         params = {"on_conflict": conflict_key} if conflict_key else {}
         resp = table.upsert(entry, **params).execute()
         return resp.data[0]["id"]
+
+
+def load_latest(prefix: str) -> bytes:
+    """Return bytes for the most recent model matching ``prefix``.
+
+    This lightweight helper only implements local file loading. ``prefix`` is
+    joined with ``.pkl`` and read from disk. Callers should handle any
+    ``FileNotFoundError`` exceptions.
+    """
+
+    path = Path(f"{prefix}.pkl")
+    with path.open("rb") as fh:
+        return fh.read()

--- a/src/cointrainer/train/enqueue.py
+++ b/src/cointrainer/train/enqueue.py
@@ -1,0 +1,21 @@
+"""Stub for training task enqueueing.
+
+This module defines a no-op function ``enqueue_retrain`` which will
+later be wired to a real asynchronous job queue. Runtime code can call
+this function without introducing heavy dependencies.
+"""
+
+from __future__ import annotations
+
+
+def enqueue_retrain(agent: str, **kwargs) -> None:
+    """Stub retrain enqueue function.
+
+    Parameters
+    ----------
+    agent: str
+        Identifier of the agent to retrain.
+    **kwargs:
+        Additional keyword arguments.
+    """
+    return None

--- a/src/crypto_bot/config.py
+++ b/src/crypto_bot/config.py
@@ -1,0 +1,12 @@
+"""Lightweight runtime configuration."""
+
+from __future__ import annotations
+
+import os
+
+
+class Config:
+    """Runtime configuration populated from environment variables."""
+
+    SYMBOL: str = os.getenv("SYMBOL", "BTCUSDT")
+    MODELS_BUCKET: str = os.getenv("MODELS_BUCKET", "models")

--- a/src/crypto_bot/regime/api.py
+++ b/src/crypto_bot/regime/api.py
@@ -1,0 +1,72 @@
+"""Runtime prediction API for regime classification."""
+
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass
+from io import BytesIO
+from pathlib import Path
+from typing import Literal, Optional
+
+import joblib
+import pandas as pd
+
+from crypto_bot.config import Config
+from cointrainer import registry as _registry
+from cointrainer.train.enqueue import enqueue_retrain
+
+Action = Literal["long", "flat", "short"]
+
+
+@dataclass
+class Prediction:
+    action: Action
+    score: float
+    regime: Optional[str] = None
+    meta: dict | None = None
+
+
+_CLASS_MAP = ["short", "flat", "long"]
+_FALLBACK_B64_PATH = Path(__file__).resolve().parents[3] / "fallback_b64.txt"
+try:  # pragma: no cover - file may be absent in some installs
+    _FALLBACK_MODEL_B64 = _FALLBACK_B64_PATH.read_text().strip()
+except Exception:  # pragma: no cover - fallback not bundled
+    _FALLBACK_MODEL_B64 = ""
+
+_MODEL: object | None = None
+
+
+def _load_model() -> object:
+    """Load the regime model, falling back to embedded base64."""
+
+    global _MODEL
+    if _MODEL is not None:
+        return _MODEL
+
+    prefix = f"{Config.MODELS_BUCKET}/regime/{Config.SYMBOL}"
+    try:
+        data = _registry.load_latest(prefix)
+        _MODEL = joblib.load(BytesIO(data))
+        return _MODEL
+    except Exception:
+        try:  # pragma: no cover - external side effect
+            enqueue_retrain("regime", symbol=Config.SYMBOL)
+        except Exception:
+            pass
+        if not _FALLBACK_MODEL_B64:
+            raise RuntimeError("Fallback model missing")
+        data = base64.b64decode(_FALLBACK_MODEL_B64)
+        _MODEL = joblib.load(BytesIO(data))
+        return _MODEL
+
+
+def predict(features: pd.DataFrame) -> Prediction:
+    """Return a :class:`Prediction` for the given ``features``."""
+
+    model = _load_model()
+    proba = model.predict_proba(features.tail(1))  # type: ignore[attr-defined]
+    row = proba[-1]
+    idx = int(row.argmax())
+    score = float(row.max())
+    action = _CLASS_MAP[idx]
+    return Prediction(action=action, score=score)

--- a/tests/test_predict_stub.py
+++ b/tests/test_predict_stub.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+from crypto_bot.regime import api
+
+
+def test_predict_fallback(monkeypatch):
+    def raise_err(prefix: str) -> bytes:
+        raise FileNotFoundError
+
+    monkeypatch.setattr(api._registry, "load_latest", raise_err)
+
+    class DummyModel:
+        def predict_proba(self, X):
+            return np.array([[0.2, 0.3, 0.5]])
+
+    monkeypatch.setattr(api.joblib, "load", lambda _: DummyModel())
+
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    result = api.predict(df)
+
+    assert result.action in {"long", "flat", "short"}
+    assert 0.0 <= result.score <= 1.0
+    assert isinstance(result, api.Prediction)

--- a/tests/test_runtime_import.py
+++ b/tests/test_runtime_import.py
@@ -1,0 +1,11 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+
+def test_runtime_import():
+    from crypto_bot.regime.api import Prediction, predict
+
+    assert Prediction.__name__ == "Prediction"
+    assert callable(predict)


### PR DESCRIPTION
## Summary
- add lightweight `crypto_bot.regime.api.predict` with registry load and base64 fallback
- provide runtime `Config` and stubbed `enqueue_retrain`
- cover import and fallback prediction paths with tests

## Testing
- `pytest tests/test_runtime_import.py tests/test_predict_stub.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a39fd014c8330b500511ff26b8923