### PR TITLE
fix(runtime): metadata-driven class mapping + feature alignment

### DIFF
--- a/src/cointrainer/registry.py
+++ b/src/cointrainer/registry.py
@@ -155,8 +155,8 @@ class ModelRegistry:
 # ---------------------------------------------------------------------------
 
 
-class RegistryError(RuntimeError):
-    """Raised when interacting with the model registry fails."""
+class RegistryError(Exception):
+    pass
 
 
 def _get_bucket():  # pragma: no cover - thin wrapper
@@ -210,6 +210,17 @@ def save_model(key: str, blob: bytes, metadata: dict) -> None:
         raise RegistryError(f"failed to save model: {exc}") from exc
 
 
+def load_pointer(prefix: str) -> dict:
+    """Return metadata from ``{prefix}/LATEST.json``."""
+
+    path = f"{prefix}/LATEST.json"
+    try:
+        data = _download(path)
+        return json.loads(data.decode())
+    except Exception as exc:
+        raise RegistryError(str(exc)) from exc
+
+
 def load_latest(prefix: str, allow_fallback: bool = False) -> bytes:
     """Return bytes for the model referenced by ``{prefix}/LATEST.json``."""
 
@@ -232,6 +243,7 @@ __all__ = [
     "ModelRegistry",
     "RegistryError",
     "save_model",
+    "load_pointer",
     "load_latest",
 ]
 

--- a/tests/test_feature_reorder.py
+++ b/tests/test_feature_reorder.py
@@ -1,0 +1,33 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+from crypto_bot.regime import api
+
+
+class DummyModel:
+    def __init__(self):
+        self.seen = None
+
+    def predict_proba(self, X):
+        self.seen = list(X.columns)
+        return np.array([[0.1, 0.2, 0.7]])
+
+
+def test_feature_reorder(monkeypatch):
+    api._MODEL = None
+    api._META = None
+
+    model = DummyModel()
+    monkeypatch.setattr(api._registry, "load_pointer", lambda prefix: {"feature_list": ["a", "b", "c"]})
+    monkeypatch.setattr(api._registry, "load_latest", lambda prefix: b"model")
+    monkeypatch.setattr(api.joblib, "load", lambda buf: model)
+
+    df = pd.DataFrame({"c": [3], "a": [1], "b": [2]})
+    api.predict(df)
+
+    assert model.seen == ["a", "b", "c"]

--- a/tests/test_label_mapping.py
+++ b/tests/test_label_mapping.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+from crypto_bot.regime import api
+
+
+class DummyModel:
+    def predict_proba(self, X):
+        return np.array([[0.1, 0.2, 0.7]])
+
+
+def test_label_mapping(monkeypatch):
+    api._MODEL = None
+    api._META = None
+
+    monkeypatch.setattr(api._registry, "load_pointer", lambda prefix: {"label_order": [1, 0, -1]})
+    monkeypatch.setattr(api._registry, "load_latest", lambda prefix: b"model")
+    monkeypatch.setattr(api.joblib, "load", lambda buf: DummyModel())
+
+    df = pd.DataFrame({"a": [1], "b": [2], "c": [3]})
+    result = api.predict(df)
+
+    assert result.action == "short"


### PR DESCRIPTION
## Summary
- enforce simple `RegistryError` and add `load_pointer` to read model metadata
- align regime model inference with `feature_list` and `label_order` from metadata, mapping probabilities to actions
- cover label mapping and feature reordering with new unit tests

## Testing
- `pytest tests/test_label_mapping.py tests/test_feature_reorder.py tests/test_predict_stub.py tests/test_registry.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689a765dc27483309659660bbb4bbde1