### PR TITLE
ci: lint+tests matrix and optional publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,64 @@ on:
   pull_request:
   push:
     branches: [main]
+    tags:
+      - 'v*'
 
 jobs:
   test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11"]
+        env: [base, train]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ matrix.python-version }}-${{ hashFiles('**/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-${{ matrix.python-version }}-
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ "${{ matrix.env }}" = "base" ]; then
+            pip install -e ".[dev]"
+          else
+            pip install -e ".[dev,train]"
+          fi
+      - name: Lint
+        run: ruff check .
+      - name: Test
+        run: pytest --maxfail=1 --disable-warnings -q --cov --cov-report=xml
+      - name: Upload coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.python-version }}-${{ matrix.env }}
+          path: coverage.xml
+
+  publish:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - run: pip install -r requirements.txt flake8 flake8-isort black
-      - run: flake8
-      - run: PYTHONPATH=. pytest -q
+      - name: Install build
+        run: python -m pip install build
+      - name: Build
+        run: python -m build
+      - name: Publish to TestPyPI
+        if: secrets.TEST_PYPI_API_TOKEN != ''
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          repository-url: https://test.pypi.org/legacy/
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # coinTrader Trainer
 
+[![CI](https://github.com/OWNER/coinTrader_Trainer/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/OWNER/coinTrader_Trainer/actions/workflows/ci.yml)
+
 Now installable via `pip install -e .` and importable via `import cointrainer`.
 
 coinTrader Trainer forms the model training component of the broader

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ gpu = ["pyopencl"]
 flwr = ["flwr"]
 talib = ["TA-Lib"]
 accel = ["numba", "jax"]
-dev = ["ruff", "vulture", "pytest-cov"]
+dev = ["ruff", "vulture", "pytest", "pytest-cov", "build"]
 
 [project.scripts]
 cointrainer = "cointrainer.cli:main"


### PR DESCRIPTION
## Summary
- add matrix GitHub Actions workflow for lint/tests and optional TestPyPI publish
- expose workflow badge in README
- include build and pytest in dev extras for packaging and tests

## Testing
- `ruff check .`
- `pytest --maxfail=1 --disable-warnings -q` *(fails: KeyError: 'start')*

------
https://chatgpt.com/codex/tasks/task_e_689bb11e80b883309ff033ffb5947f65