### PR TITLE
feat(csv7): CSV7 ingestion module and test

### DIFF
--- a/src/cointrainer/io/__init__.py
+++ b/src/cointrainer/io/__init__.py
@@ -1,0 +1,1 @@
+"""IO utilities for cointrainer package."""

--- a/src/cointrainer/io/csv7.py
+++ b/src/cointrainer/io/csv7.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+from pathlib import Path
+from typing import Union, Literal, IO
+import pandas as pd
+
+CsvLike = Union[str, Path, IO[str]]
+
+def read_csv7(path: CsvLike, *, tz: Literal["utc","naive"]="utc") -> pd.DataFrame:
+    """
+    Read a headerless 7-column CSV in the order:
+      ts, open, high, low, close, volume, trades
+
+    - ts is epoch seconds or milliseconds (auto-detected).
+    - Returns OHLCV(+trades) with a UTC datetime index named 'ts'.
+    """
+    p = path if hasattr(path, "read") else Path(path)
+    df = pd.read_csv(p, header=None,
+                     names=["ts", "open", "high", "low", "close", "volume", "trades"],
+                     low_memory=False)
+    # numeric coercion
+    for c in ["ts", "open", "high", "low", "close", "volume", "trades"]:
+        df[c] = pd.to_numeric(df[c], errors="coerce")
+
+    df = df.dropna(subset=["ts", "open", "high", "low", "close", "volume"]).copy()
+
+    # infer epoch unit (ms vs s)
+    median_ts = df["ts"].median()
+    unit = "ms" if median_ts > 1e12 else "s"
+
+    dt = pd.to_datetime(df["ts"].astype("int64"), unit=unit, utc=True)
+    if tz == "naive":
+        dt = dt.tz_localize(None)
+
+    df["ts"] = dt
+    df = (df.sort_values("ts")
+            .drop_duplicates("ts")
+            .set_index("ts"))
+    df.index.name = "ts"
+    # enforce column order
+    cols = ["open", "high", "low", "close", "volume", "trades"]
+    return df[cols]

--- a/tests/test_csv7_ingest.py
+++ b/tests/test_csv7_ingest.py
@@ -1,0 +1,11 @@
+import io
+import pandas as pd
+from cointrainer.io.csv7 import read_csv7
+
+def test_read_csv7_basic():
+    s = io.StringIO("1495122660,0.35,0.35,0.35,0.35,2.0,1\n1495122720,0.35,0.36,0.34,0.35,3.0,2\n")
+    df = read_csv7(s)
+    assert list(df.columns) == ["open","high","low","close","volume","trades"]
+    assert df.index.name == "ts"
+    assert len(df) == 2
+    assert pd.api.types.is_datetime64_any_dtype(df.index)


### PR DESCRIPTION
## Summary
- add csv7 reader for headerless 7-column OHLCV CSVs
- basic ingestion test for csv7

## Testing
- `pytest -q` *(fails: KeyError: 'start', Invalid URL, etc.)*
- `PYTHONPATH=src pytest tests/test_csv7_ingest.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689d02e190488330aba700294396f17e