### PR TITLE
chore(deps): runtime vs train extras split

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,46 @@
 [build-system]
-requires = ["setuptools>=61"]
+requires = ["setuptools>=68", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.setuptools]
+package-dir = {"" = "src"}
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [project]
 name = "cointrader-trainer"
 version = "0.1.0"
 requires-python = ">=3.10"
 dependencies = [
-    "pandas",
-    "numpy",
-    "pyarrow",
-    "pytz",
-    "tenacity",
-    "requests",
+  "pandas>=2.2",
+  "numpy>=1.26",
+  "pyarrow>=16; extra == 'train' or extra == 'dev'",  # OPTIONAL: leave pyarrow out of base
+  "pytz",
+  "tenacity",
+  "requests",
 ]
 
 [project.optional-dependencies]
-train = ["lightgbm", "scikit-learn", "optuna", "networkx", "backtrader"]
+train = [
+  "lightgbm>=4.0",
+  "scikit-learn>=1.4",
+  "joblib>=1.3",
+  "networkx",
+]
+dev = [
+  "pytest>=8",
+  "pytest-cov>=5",
+  "hypothesis>=6",
+  "ruff",
+  "vulture",
+]
 gpu = ["pyopencl"]
 flwr = ["flwr"]
 talib = ["TA-Lib"]
 accel = ["numba", "jax"]
-dev = ["ruff", "vulture", "pytest", "pytest-cov", "build"]
 
 [project.scripts]
 cointrainer = "cointrainer.cli:main"
 
-[tool.setuptools.packages.find]
-where = ["src"]


### PR DESCRIPTION
## Summary
- document CSV7 ingest & local training (1-minute bars)
- keep heavy training dependencies under `[train]` extra to keep runtime light

## Testing
- `pip install -e .[dev]`
- `pytest` *(fails: supabase URL, missing data, and other environment-related errors)*

------
https://chatgpt.com/codex/tasks/task_e_689d033006a4833093af9dc758159fc1