### PR TITLE
feat(cli): batch training over CSV folders

### DIFF
--- a/src/cointrainer/train/local_csv.py
+++ b/src/cointrainer/train/local_csv.py
@@ -83,8 +83,12 @@ def _maybe_publish_registry(model_bytes: bytes, metadata: dict, cfg: TrainConfig
     except Exception:
         return None
 
-def train_from_csv7(csv_path: Path | str, cfg: TrainConfig) -> tuple[object, dict]:
+def train_from_csv7(
+    csv_path: Path | str, cfg: TrainConfig, limit_rows: int | None = None
+) -> tuple[object, dict]:
     df = read_csv7(csv_path)
+    if limit_rows is not None:
+        df = df.tail(int(limit_rows))
     X_all = make_features(df).dropna()
     y_all = make_labels(df.loc[X_all.index, "close"], cfg.horizon, cfg.hold)
     m = y_all.notna()

--- a/src/cointrainer/utils/__init__.py
+++ b/src/cointrainer/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for batch training and file handling."""

--- a/src/cointrainer/utils/batch.py
+++ b/src/cointrainer/utils/batch.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def iter_csv_files(folder: str | Path, glob: str = "*.csv", recursive: bool = False) -> list[Path]:
+    """Return a list of CSV files under *folder* matching *glob*.
+
+    Parameters
+    ----------
+    folder: str | Path
+        Root directory to search.
+    glob: str
+        Glob pattern to match files. Defaults to ``"*.csv"``.
+    recursive: bool
+        If ``True`` search subdirectories recursively.
+    """
+    root = Path(folder)
+    if not root.exists():
+        return []
+    files = list(root.rglob(glob)) if recursive else list(root.glob(glob))
+    return [f for f in files if f.is_file()]
+
+
+def is_csv7(path: str | Path) -> bool:
+    """Return ``True`` if the file appears to be a headerless 7-column CSV."""
+    try:
+        with Path(path).open("r", encoding="utf-8") as fh:
+            first = fh.readline().strip()
+    except Exception:
+        return False
+    parts = first.split(",")
+    if len(parts) != 7:
+        return False
+    for p in parts:
+        try:
+            float(p)
+        except ValueError:
+            return False
+    return True
+
+
+def is_normalized_csv(path: str | Path) -> bool:
+    """Return ``True`` if the file looks like a normalized OHLCV CSV."""
+    try:
+        with Path(path).open("r", encoding="utf-8") as fh:
+            header = fh.readline().lower()
+    except Exception:
+        return False
+    return all(h in header for h in ["open", "high", "low", "close", "volume"])
+
+
+def derive_symbol(path: Path, mode: str = "filename", fixed: str | None = None) -> str:
+    """Derive a trading symbol from *path* according to *mode*.
+
+    ``mode`` may be ``"filename"`` (default) which uses the stem of the
+    filename, ``"parent"`` which uses the name of the parent directory, or
+    ``"fixed"`` which returns ``fixed``.
+    """
+    if mode == "filename":
+        return path.stem.split("_")[0].upper()
+    if mode == "parent":
+        return path.parent.name.upper()
+    if mode == "fixed":
+        if not fixed:
+            raise ValueError("symbol must be provided when mode='fixed'")
+        return fixed.upper()
+    raise ValueError(f"Unknown derive mode: {mode}")


### PR DESCRIPTION
## Summary
- add `csv-train-batch` command to train one model per CSV and produce a summary
- support batch file iteration & symbol derivation utilities
- allow limiting rows in `train_from_csv7`

## Testing
- `ruff check src/cointrainer/cli.py src/cointrainer/train/local_csv.py src/cointrainer/utils/batch.py`
- `PYTHONPATH=src pytest tests/test_cli_help.py tests/test_cli_flags.py tests/test_csv_train_smoke.py`


------
https://chatgpt.com/codex/tasks/task_e_689d28f531dc83309cb724230c0337f9