### PR TITLE
Ensure default model environment variables

### DIFF
--- a/src/cointrainer/__init__.py
+++ b/src/cointrainer/__init__.py
@@ -1,9 +1,33 @@
 """cointrainer package."""
+
 from importlib.metadata import PackageNotFoundError, version
+import os
+
+
+def ensure_env_defaults() -> None:
+    """Populate default environment variables used by coinTrader."""
+
+    models_bucket = (
+        os.getenv("CT_MODELS_BUCKET")
+        or os.getenv("MODELS_BUCKET")
+        or "models"
+    )
+    regime_prefix = os.getenv("CT_REGIME_PREFIX") or "models/regime"
+    symbol = os.getenv("SYMBOL", "BTCUSDT")
+
+    os.environ.setdefault("CT_MODELS_BUCKET", models_bucket)
+    os.environ.setdefault("CT_REGIME_PREFIX", regime_prefix)
+    # Mirror to legacy names for backward compatibility
+    os.environ.setdefault("MODELS_BUCKET", models_bucket)
+    os.environ.setdefault("REGIME_PREFIX", f"{regime_prefix}/{symbol}")
+
+
+# Ensure defaults when the package is imported
+ensure_env_defaults()
 
 try:
     __version__ = version("cointrader-trainer")
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "0.1.0"
 
-__all__ = ["__version__"]
+__all__ = ["__version__", "ensure_env_defaults"]

--- a/src/crypto_bot/config.py
+++ b/src/crypto_bot/config.py
@@ -4,10 +4,15 @@ from __future__ import annotations
 
 import os
 
+from cointrainer import ensure_env_defaults
+
+# Ensure defaults before reading configuration
+ensure_env_defaults()
+
 
 class Config:
     """Runtime configuration populated from environment variables."""
 
     SYMBOL: str = os.getenv("SYMBOL", "BTCUSDT")
-    MODELS_BUCKET: str = os.getenv("MODELS_BUCKET", "models")
+    MODELS_BUCKET: str = os.getenv("CT_MODELS_BUCKET", "models")
     REGIME_PREFIX: str = os.getenv("REGIME_PREFIX", f"{MODELS_BUCKET}/regime/{SYMBOL}")


### PR DESCRIPTION
## Summary
- set default CT_MODELS_BUCKET and CT_REGIME_PREFIX environment variables
- propagate environment defaults before configuration is read

## Testing
- `ruff check .`
- `pytest` *(fails: SyntaxError in cointrainer/train/local_csv.py)*

------
https://chatgpt.com/codex/tasks/task_e_689d3ab1372483309cf7991b25b6d989