### PR TITLE
feat(backtest): core simulator & metrics

### DIFF
--- a/src/cointrainer/backtest/__init__.py
+++ b/src/cointrainer/backtest/__init__.py
@@ -1,0 +1,23 @@
+"""Backtesting utilities for cointrainer."""
+
+from .sim import simulate
+from .metrics import (
+    drawdown_curve,
+    max_drawdown,
+    sharpe,
+    sortino,
+    cagr,
+    hit_rate,
+    summarize,
+)
+
+__all__ = [
+    "simulate",
+    "drawdown_curve",
+    "max_drawdown",
+    "sharpe",
+    "sortino",
+    "cagr",
+    "hit_rate",
+    "summarize",
+]

--- a/src/cointrainer/backtest/metrics.py
+++ b/src/cointrainer/backtest/metrics.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+
+def drawdown_curve(equity: pd.Series) -> pd.Series:
+    peak = equity.cummax()
+    dd = (equity / peak) - 1.0
+    return dd
+
+def max_drawdown(equity: pd.Series) -> float:
+    return float(drawdown_curve(equity).min())
+
+def sharpe(returns: pd.Series, periods_per_year: float) -> float:
+    # assumes zero rf; returns are arithmetic per period
+    if len(returns) < 2:
+        return 0.0
+    s = returns.std(ddof=0)
+    if s == 0 or np.isnan(s):
+        return 0.0
+    return float((returns.mean() * periods_per_year) / (s * np.sqrt(periods_per_year)))
+
+def sortino(returns: pd.Series, periods_per_year: float) -> float:
+    neg = returns.copy()
+    neg[neg > 0] = 0
+    dn = neg.std(ddof=0)
+    if dn == 0 or np.isnan(dn):
+        return 0.0
+    return float((returns.mean() * periods_per_year) / (dn * np.sqrt(periods_per_year)))
+
+def cagr(equity: pd.Series, periods_per_year: float) -> float:
+    if len(equity) < 2:
+        return 0.0
+    total = float(equity.iloc[-1] / equity.iloc[0])
+    years = len(equity) / periods_per_year
+    if years <= 0:
+        return 0.0
+    return float(total ** (1.0 / years) - 1.0)
+
+def hit_rate(ret_per_trade: pd.Series) -> float:
+    if len(ret_per_trade) == 0:
+        return 0.0
+    wins = (ret_per_trade > 0).sum()
+    return float(wins / len(ret_per_trade))
+
+def summarize(equity: pd.Series, net_ret: pd.Series, trades_idx: pd.Index, periods_per_year: float) -> dict:
+    dd = max_drawdown(equity)
+    trades = len(trades_idx)
+    return {
+        "cagr": cagr(equity, periods_per_year),
+        "sharpe": sharpe(net_ret, periods_per_year),
+        "sortino": sortino(net_ret, periods_per_year),
+        "max_drawdown": dd,
+        "calmar": (cagr(equity, periods_per_year) / abs(dd)) if dd != 0 else 0.0,
+        "turnover": float(trades / len(equity)),
+        "trades": int(trades),
+        "trades_per_day": float(trades / (len(equity) / (60 * 24))),  # for 1m bars
+        "final_equity": float(equity.iloc[-1]),
+    }

--- a/src/cointrainer/backtest/signals.py
+++ b/src/cointrainer/backtest/signals.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+
+def confidence_gate(classes: np.ndarray, proba: np.ndarray, open_thr: float, close_thr: float | None = None) -> np.ndarray:
+    """
+    Apply confidence gating/hysteresis:
+      - open/flip only if max proba > open_thr
+      - optionally hold position until max proba falls below close_thr (default: open_thr)
+    """
+    if close_thr is None:
+        close_thr = open_thr
+    pos = np.zeros_like(classes, dtype=float)
+    cur = 0.0
+    for i, (c, p) in enumerate(zip(classes, proba)):
+        m = float(np.max(p))
+        k = int(np.argmax(p))
+        proposed = (-1.0 if k == 0 else 0.0 if k == 1 else 1.0)  # order [-1,0,1]
+        if cur == 0.0:
+            if m > open_thr:
+                cur = proposed
+        else:
+            if m < close_thr:
+                cur = 0.0
+            else:
+                if proposed != cur and m > open_thr:
+                    cur = proposed
+        pos[i] = cur
+    return pos
+
+def sized_position(classes: np.ndarray, proba: np.ndarray, base: float = 1.0, scale: float = 2.0, open_thr: float = 0.5) -> np.ndarray:
+    """
+    Continuous position sizing: size = base * ((max_proba - 0.5)*scale)+
+    """
+    idx = np.argmax(proba, axis=1)
+    signed = np.where(idx==0, -1.0, np.where(idx==1, 0.0, 1.0))
+    conf = np.clip((np.max(proba, axis=1) - 0.5) * scale, 0.0, 1.0)
+    conf = np.where(np.max(proba, axis=1) >= open_thr, conf, 0.0)
+    return base * signed * conf

--- a/src/cointrainer/backtest/sim.py
+++ b/src/cointrainer/backtest/sim.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+import numpy as np
+import pandas as pd
+from typing import Literal, Callable, Dict
+from .metrics import summarize
+
+def simulate(
+    prices: pd.Series,
+    position: pd.Series | np.ndarray,
+    fee_bps: float = 2.0,          # per side, in basis points
+    slip_bps: float = 0.0,         # slippage per trade, bps
+    periods_per_year: float = 525600.0,  # 1-min bars
+) -> Dict:
+    """
+    Vectorized PnL simulation:
+      - position in [-1..1], same length as prices
+      - fees charged when position changes (turnover)
+      - returns are close-to-close
+    """
+    position = pd.Series(position, index=prices.index).astype(float)
+    ret = prices.pct_change().fillna(0.0)
+    pos_prev = position.shift(1).fillna(0.0)
+    turnover = (position - pos_prev).abs()
+    fee = (fee_bps / 1e4) * turnover
+    slip = (slip_bps / 1e4) * turnover
+    gross = position * ret
+    net = gross - fee - slip
+    equity = (1.0 + net).cumprod()
+    trades_idx = turnover[turnover > 0.0].index
+    stats = summarize(equity, net, trades_idx, periods_per_year)
+    return {"equity": equity, "net": net, "turnover": turnover, "stats": stats}

--- a/tests/test_backtest_sim.py
+++ b/tests/test_backtest_sim.py
@@ -1,0 +1,16 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+from cointrainer.backtest.sim import simulate
+
+
+def test_sim_basic():
+    idx = pd.date_range("2025-01-01", periods=100, freq="T", tz="UTC")
+    price = pd.Series(100.0 * (1.0 + 0.0005*np.sin(np.arange(100)/10)).cumprod(), index=idx)
+    pos = np.where(np.arange(100) % 10 < 5, 1.0, 0.0)  # long half the time
+    res = simulate(price, pos, fee_bps=2.0, slip_bps=0.0)
+    assert "stats" in res and "final_equity" in res["stats"]


### PR DESCRIPTION
## Summary
- add vectorized backtesting metrics (drawdown, sharpe, cagr, etc.)
- implement signal builders for confidence gating and size scaling
- provide pure-Python simulator with turnover, fees, and summary stats

## Testing
- `pytest tests/test_backtest_sim.py::test_sim_basic -q`
- `ruff check src/cointrainer/backtest tests/test_backtest_sim.py`


------
https://chatgpt.com/codex/tasks/task_e_689e41ded910833096f309370c9e59ea