### PR TITLE
feat(backtest): add backtest CLI

### DIFF
--- a/src/cointrainer/backtest/run.py
+++ b/src/cointrainer/backtest/run.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+import json, io
+from pathlib import Path
+import numpy as np
+import pandas as pd
+from typing import Optional, Dict, Any
+
+from cointrainer.features.simple_indicators import ema, rsi, atr, roc, obv
+from cointrainer.backtest.signals import confidence_gate, sized_position
+from cointrainer.backtest.sim import simulate
+from cointrainer.train.local_csv import FEATURE_LIST
+from cointrainer.io.csv7 import read_csv7
+
+def build_features(df: pd.DataFrame) -> pd.DataFrame:
+    close, high, low, vol = df["close"], df["high"], df["low"], df["volume"]
+    X = pd.DataFrame(index=df.index)
+    X["ema_8"]  = ema(close, 8)
+    X["ema_21"] = ema(close, 21)
+    X["rsi_14"] = rsi(close, 14)
+    X["atr_14"] = atr(high, low, close, 14)
+    X["roc_5"]  = roc(close, 5)
+    X["obv"]    = obv(close, vol)
+    return X.dropna()
+
+def load_model_local(path: Path):
+    import joblib
+    return joblib.load(path)
+
+def load_model_registry(prefix: str):
+    from cointrainer.registry import load_pointer, load_latest
+    meta = load_pointer(prefix)
+    blob = load_latest(prefix)
+    model = _unpack_model(blob)
+    return model, meta
+
+def _unpack_model(blob: bytes):
+    # try joblib then pickle
+    try:
+        import joblib, io
+        return joblib.load(io.BytesIO(blob))
+    except Exception:
+        import pickle
+        return pickle.loads(blob)
+
+def backtest_csv(
+    path: Path,
+    symbol: str,
+    model_local: Optional[Path] = None,
+    model_registry_prefix: Optional[str] = None,
+    outdir: Path = Path("out") / "backtests",
+    open_thr: float = 0.55,
+    close_thr: Optional[float] = None,
+    fee_bps: float = 2.0,
+    slip_bps: float = 0.0,
+    position_mode: str = "gated",   # "gated" | "sized"
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+) -> Dict[str, Any]:
+    # 1) Load data (normalized or CSV7)
+    p = Path(path)
+    if p.exists():
+        try:
+            df = pd.read_csv(p, parse_dates=[0], index_col=0).sort_index()
+        except Exception:
+            df = read_csv7(p)  # autodetect CSV7
+    else:
+        raise FileNotFoundError(path)
+
+    if start: df = df[df.index >= pd.Timestamp(start, tz="UTC")]
+    if end:   df = df[df.index <= pd.Timestamp(end, tz="UTC")]
+
+    # 2) Build features and align to FEATURE_LIST
+    X = build_features(df)
+    cols = [c for c in FEATURE_LIST if c in X.columns]
+    X = X[cols]
+    idx = X.index
+
+    # 3) Load model
+    meta = {"feature_list": FEATURE_LIST, "label_order": [-1,0,1]}
+    if model_local:
+        model = load_model_local(Path(model_local))
+    elif model_registry_prefix:
+        model, meta = load_model_registry(model_registry_prefix)
+        feat_list = meta.get("feature_list", FEATURE_LIST)
+        X = X[[c for c in feat_list if c in X.columns]]
+    else:
+        raise ValueError("Provide model_local or model_registry_prefix")
+
+    # 4) Predict proba
+    proba = model.predict_proba(X.values)
+    # class order expected [-1,0,1]; if different, map here using meta["label_order"]
+    order = meta.get("label_order", [-1,0,1])
+    # If order != [-1,0,1], we need to reorder columns of proba accordingly
+    if order != [-1,0,1]:
+        # build mapping from order index to canonical index
+        mapping = {c:i for i,c in enumerate(order)}
+        cols_map = [mapping[-1], mapping[0], mapping[1]]
+        proba = proba[:, cols_map]
+
+    # 5) Build positions
+    if position_mode == "gated":
+        pos = confidence_gate(np.zeros(len(X), dtype=int), proba, open_thr=open_thr, close_thr=close_thr)
+    else:
+        pos = sized_position(np.zeros(len(X), dtype=int), proba, base=1.0, scale=2.0, open_thr=open_thr)
+
+    # 6) Simulate
+    res = simulate(df.loc[idx, "close"], pos, fee_bps=fee_bps, slip_bps=slip_bps)
+
+    # 7) Save artifacts
+    ddir = outdir / symbol
+    ddir.mkdir(parents=True, exist_ok=True)
+    ts = pd.Timestamp.utcnow().strftime("%Y%m%d-%H%M%S")
+    (ddir / f"equity_{ts}.csv").write_text(res["equity"].to_csv(index=True))
+    (ddir / f"summary_{ts}.json").write_text(json.dumps(res["stats"], indent=2))
+    return res

--- a/src/cointrainer/backtest/signals.py
+++ b/src/cointrainer/backtest/signals.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+import numpy as np
+from typing import Optional
+
+__all__ = ["confidence_gate", "sized_position"]
+
+def confidence_gate(
+    _base: np.ndarray,
+    proba: np.ndarray,
+    *,
+    open_thr: float = 0.55,
+    close_thr: Optional[float] = None,
+) -> np.ndarray:
+    """Convert class probabilities to {-1,0,1} positions using gating.
+
+    Parameters
+    ----------
+    _base : np.ndarray
+        Placeholder for existing positions (unused currently).
+    proba : np.ndarray
+        Array of shape (n_samples, 3) with probabilities ordered as [-1,0,1].
+    open_thr : float
+        Minimum probability required to open a position.
+    close_thr : float | None
+        Probability threshold to keep an existing position open. If ``None``
+        the ``open_thr`` is used.
+    """
+
+    thr_close = close_thr if close_thr is not None else open_thr
+    out: list[int] = []
+    current = 0
+    for p_short, _, p_long in proba:
+        if current == 0:
+            if p_long >= open_thr and p_long >= p_short:
+                current = 1
+            elif p_short >= open_thr and p_short > p_long:
+                current = -1
+        else:
+            curr_prob = p_long if current > 0 else p_short
+            if curr_prob < thr_close:
+                current = 0
+                if p_long >= open_thr and p_long >= p_short:
+                    current = 1
+                elif p_short >= open_thr and p_short > p_long:
+                    current = -1
+        out.append(current)
+    return np.asarray(out, dtype=int)
+
+def sized_position(
+    _base: np.ndarray,
+    proba: np.ndarray,
+    *,
+    base: float = 1.0,
+    scale: float = 2.0,
+    open_thr: float = 0.55,
+) -> np.ndarray:
+    """Size positions proportional to probability confidence.
+
+    Parameters
+    ----------
+    proba : np.ndarray
+        Probabilities ordered as [-1,0,1].
+    base : float
+        Base position size when threshold met.
+    scale : float
+        Additional scale applied above ``open_thr``.
+    open_thr : float
+        Minimum probability to take a position.
+    """
+    out: list[float] = []
+    for p_short, _, p_long in proba:
+        if p_long >= open_thr and p_long > p_short:
+            size = base + scale * (p_long - open_thr) / (1 - open_thr)
+            out.append(size)
+        elif p_short >= open_thr and p_short > p_long:
+            size = base + scale * (p_short - open_thr) / (1 - open_thr)
+            out.append(-size)
+        else:
+            out.append(0.0)
+    return np.asarray(out, dtype=float)

--- a/src/cointrainer/backtest/sim.py
+++ b/src/cointrainer/backtest/sim.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+from typing import Dict, Any
+
+__all__ = ["simulate"]
+
+def simulate(
+    prices: pd.Series,
+    positions: np.ndarray,
+    *,
+    fee_bps: float = 2.0,
+    slip_bps: float = 0.0,
+) -> Dict[str, Any]:
+    """Simulate equity curve from price series and positions.
+
+    Parameters
+    ----------
+    prices : pandas.Series
+        Price series aligned to ``positions``.
+    positions : np.ndarray
+        Array of position values (can be fractional).
+    fee_bps : float
+        Transaction fee in basis points applied on position changes.
+    slip_bps : float
+        Slippage in basis points applied on position changes.
+    """
+
+    prices = prices.astype(float)
+    ret = prices.pct_change().fillna(0.0).to_numpy()
+    pos = np.asarray(positions, dtype=float)
+    if len(ret) != len(pos):
+        raise ValueError("positions length must match prices")
+
+    pnl = ret * pos
+    cost = (fee_bps + slip_bps) / 10000.0
+    pos_diff = np.diff(np.concatenate([[0.0], pos]))
+    pnl -= cost * np.abs(pos_diff)
+    equity = pd.Series((1.0 + pnl).cumprod(), index=prices.index)
+
+    mean = pnl.mean()
+    std = pnl.std(ddof=0)
+    sharpe = float(np.sqrt(365) * mean / std) if std > 0 else 0.0
+    peaks = equity.cummax()
+    drawdown = (equity / peaks) - 1.0
+    max_dd = float(drawdown.min())
+    stats = {
+        "final_equity": float(equity.iloc[-1]),
+        "total_return": float(equity.iloc[-1] - 1.0),
+        "sharpe": sharpe,
+        "max_drawdown": max_dd,
+    }
+    return {"equity": equity, "stats": stats}


### PR DESCRIPTION
## Summary
- add backtest module to build features, run models, generate positions, and simulate equity curves
- convert probabilities into trading positions and compute PnL metrics
- expose `cointrainer backtest` CLI for running model backtests and saving reports

## Testing
- `pytest` *(fails: DID NOT RAISE <class 'SystemExit'>, ValueError, SupabaseException, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e41f10d288330b3e609066f2cf78a