### PR TITLE
feat(backtest): optimizer + leaderboard

### DIFF
--- a/src/cointrainer/backtest/__init__.py
+++ b/src/cointrainer/backtest/__init__.py
@@ -1,0 +1,6 @@
+"""Backtesting helpers for cointrainer."""
+
+from .optimize import optimize_grid, optimize_optuna
+from .run import backtest_csv
+
+__all__ = ["optimize_grid", "optimize_optuna", "backtest_csv"]

--- a/src/cointrainer/backtest/optimize.py
+++ b/src/cointrainer/backtest/optimize.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from cointrainer.backtest.run import backtest_csv
+from cointrainer.io.csv7 import read_csv7
+from cointrainer.train.local_csv import TrainConfig, train_from_csv7
+
+
+def _train_one(
+    csv_path: Path,
+    symbol: str,
+    horizon: int,
+    hold: float,
+    outdir: Path,
+    device_type: str = "gpu",
+    max_bin: int = 63,
+    n_jobs: int | None = 0,
+    limit_rows: int | None = None,
+) -> Path:
+    cfg = TrainConfig(
+        symbol=symbol,
+        horizon=horizon,
+        hold=hold,
+        outdir=outdir,
+        publish_to_registry=False,
+    )
+    df = None
+    try:
+        df = pd.read_csv(csv_path, parse_dates=[0], index_col=0).sort_index()
+    except Exception:
+        df = read_csv7(csv_path)
+    if limit_rows and limit_rows > 0:
+        df = df.tail(int(limit_rows))
+        tmp = outdir / f"{symbol}_tmp.normalized.csv"
+        tmp.parent.mkdir(parents=True, exist_ok=True)
+        df.to_csv(tmp, index=True)
+        csv_path = tmp
+
+    cfg.device_type = device_type  # type: ignore[attr-defined]
+    cfg.max_bin = max_bin  # type: ignore[attr-defined]
+    cfg.n_jobs = n_jobs  # type: ignore[attr-defined]
+
+    model, meta = train_from_csv7(csv_path, cfg)
+    path = cfg.outdir / f"{symbol.lower()}_regime_lgbm.pkl"
+    return path
+
+
+def optimize_grid(
+    csv_path: Path,
+    symbol: str,
+    horizons: list[int],
+    holds: list[float],
+    open_thrs: list[float],
+    position_modes: list[str],
+    fee_bps: float,
+    slip_bps: float,
+    device_type: str = "gpu",
+    max_bin: int = 63,
+    n_jobs: int | None = 0,
+    limit_rows: int | None = None,
+    outdir: Path = Path("out/opt"),
+) -> dict[str, Any]:
+    out = outdir / symbol
+    out.mkdir(parents=True, exist_ok=True)
+    leaderboard = []
+
+    for H in horizons:
+        for hold in holds:
+            model_path = _train_one(
+                csv_path, symbol, H, hold, out, device_type, max_bin, n_jobs, limit_rows
+            )
+            for thr in open_thrs:
+                for pos_mode in position_modes:
+                    res = backtest_csv(
+                        path=csv_path,
+                        symbol=symbol,
+                        model_local=model_path,
+                        outdir=out / "backtests",
+                        open_thr=thr,
+                        close_thr=None,
+                        fee_bps=fee_bps,
+                        slip_bps=slip_bps,
+                        position_mode=pos_mode,
+                    )
+                    row = {
+                        "horizon": H,
+                        "hold": hold,
+                        "open_thr": thr,
+                        "position": pos_mode,
+                    }
+                    row.update(res["stats"])
+                    leaderboard.append(row)
+
+    lb = pd.DataFrame(leaderboard).sort_values(
+        ["cagr", "sharpe", "final_equity"], ascending=[False, False, False]
+    )
+    lb_path = out / "leaderboard.csv"
+    lb.to_csv(lb_path, index=False)
+    best = lb.iloc[0].to_dict()
+    (out / "best.json").write_text(json.dumps(best, indent=2))
+    return {"leaderboard": lb_path, "best": best}
+
+
+def optimize_optuna(
+    csv_path: Path,
+    symbol: str,
+    horizons: list[int],
+    holds: list[float],
+    open_thrs: list[float],
+    position_modes: list[str],
+    fee_bps: float,
+    slip_bps: float,
+    *,
+    n_trials: int = 30,
+    device_type: str = "gpu",
+    max_bin: int = 63,
+    n_jobs: int | None = 0,
+    limit_rows: int | None = None,
+    outdir: Path = Path("out/opt"),
+) -> dict[str, Any]:
+    try:
+        import optuna
+    except Exception as e:  # pragma: no cover - optional dep
+        raise RuntimeError("optuna is required for --optuna search") from e
+
+    out = outdir / symbol
+    out.mkdir(parents=True, exist_ok=True)
+
+    def objective(trial: optuna.Trial) -> float:
+        H = trial.suggest_categorical("horizon", horizons)
+        hold = trial.suggest_categorical("hold", holds)
+        thr = trial.suggest_categorical("open_thr", open_thrs)
+        pos_mode = trial.suggest_categorical("position", position_modes)
+        model_path = _train_one(
+            csv_path, symbol, int(H), float(hold), out, device_type, max_bin, n_jobs, limit_rows
+        )
+        res = backtest_csv(
+            path=csv_path,
+            symbol=symbol,
+            model_local=model_path,
+            outdir=out / "backtests",
+            open_thr=float(thr),
+            close_thr=None,
+            fee_bps=fee_bps,
+            slip_bps=slip_bps,
+            position_mode=str(pos_mode),
+        )
+        trial.set_user_attr("stats", res["stats"])
+        return float(res["stats"]["cagr"])
+
+    study = optuna.create_study(direction="maximize")
+    study.optimize(objective, n_trials=n_trials)
+
+    rows = []
+    for t in study.trials:
+        if t.state != optuna.trial.TrialState.COMPLETE:
+            continue
+        row = dict(t.params)
+        row.update(t.user_attrs.get("stats", {}))
+        rows.append(row)
+    lb = pd.DataFrame(rows).sort_values(
+        ["cagr", "sharpe", "final_equity"], ascending=[False, False, False]
+    )
+    lb_path = out / "leaderboard.csv"
+    lb.to_csv(lb_path, index=False)
+
+    best_params = study.best_params
+    best_stats = study.best_trial.user_attrs.get("stats", {})
+    best = dict(best_params)
+    best.update(best_stats)
+    (out / "best.json").write_text(json.dumps(best, indent=2))
+    return {"leaderboard": lb_path, "best": best}
+
+
+__all__ = ["optimize_grid", "optimize_optuna"]

--- a/src/cointrainer/backtest/run.py
+++ b/src/cointrainer/backtest/run.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+from cointrainer.io.csv7 import read_csv7
+from cointrainer.train.local_csv import make_features
+
+try:  # optional heavy dep
+    import joblib
+except Exception:  # pragma: no cover - joblib always installed in runtime
+    joblib = None  # type: ignore
+
+
+def _load_csv(path: Path) -> pd.DataFrame:
+    try:
+        df = pd.read_csv(path, parse_dates=[0], index_col=0)
+    except Exception:
+        df = read_csv7(path)
+    return df.sort_index()
+
+
+def backtest_csv(
+    *,
+    path: Path,
+    symbol: str,
+    model_local: Path,
+    outdir: Path,
+    open_thr: float,
+    close_thr: float | None,
+    fee_bps: float,
+    slip_bps: float,
+    position_mode: str,
+) -> dict[str, Any]:
+    """Run a simple threshold-based backtest over a CSV.
+
+    The CSV is loaded, features are computed and the LightGBM model stored in
+    ``model_local`` is used to generate class probabilities.  Signals are
+    derived from these probabilities using ``open_thr`` and ``position_mode``
+    and a very small PnL simulation is performed.
+    """
+
+    df = _load_csv(path)
+    X = make_features(df).dropna()
+    df = df.loc[X.index]
+
+    if joblib is None:  # pragma: no cover - defensive
+        raise RuntimeError("joblib is required to load the trained model")
+    model = joblib.load(model_local)
+    proba = model.predict_proba(X.values)
+    classes = list(model.classes_)
+    p_short = proba[:, classes.index(-1)]
+    p_long = proba[:, classes.index(1)]
+
+    if position_mode == "sized":
+        raw = p_long - p_short
+        signals = np.where(np.abs(raw) >= open_thr, raw, 0.0)
+    else:  # gated
+        signals = np.where(p_long >= open_thr, 1.0, np.where(p_short >= open_thr, -1.0, 0.0))
+
+    rets = df["close"].pct_change().fillna(0.0)
+    strat_rets = rets * signals
+    diff = np.diff(signals, prepend=0.0)
+    cost = (fee_bps + slip_bps) / 10000.0
+    strat_rets -= cost * np.abs(diff)
+
+    equity = (1.0 + strat_rets).cumprod()
+    final_equity = float(equity.iloc[-1])
+    periods_per_year = 365 * 24 * 60  # 1m bars
+    if len(strat_rets) > 0:
+        cagr = float(equity.iloc[-1] ** (periods_per_year / len(strat_rets)) - 1)
+        std = strat_rets.std(ddof=0)
+        sharpe = float(np.sqrt(periods_per_year) * strat_rets.mean() / std) if std > 0 else 0.0
+    else:
+        cagr = 0.0
+        sharpe = 0.0
+
+    stats: dict[str, Any] = {
+        "cagr": cagr,
+        "sharpe": sharpe,
+        "final_equity": final_equity,
+    }
+
+    outdir.mkdir(parents=True, exist_ok=True)
+    (outdir / f"{symbol.lower()}_signals.csv").write_text(
+        "ts,signal\n" + "\n".join(f"{ts},{sig}" for ts, sig in zip(df.index, signals, strict=False))
+    )
+
+    return {"stats": stats}
+
+
+__all__ = ["backtest_csv"]

--- a/src/cointrainer/cli.py
+++ b/src/cointrainer/cli.py
@@ -59,7 +59,6 @@ def _cmd_csv_train(args: argparse.Namespace) -> None:
     from cointrainer.train.local_csv import (
         FEATURE_LIST,
         TrainConfig,
-        _dataset_fingerprint,
         _fit_model,
         _maybe_publish_registry,
         _save_local,
@@ -120,7 +119,9 @@ def _cmd_csv_train(args: argparse.Namespace) -> None:
         }
         path = _save_local(model, cfg, meta)
         try:
-            import io, joblib
+            import io
+
+            import joblib
 
             buf = io.BytesIO()
             joblib.dump(model, buf)
@@ -145,7 +146,6 @@ def _cmd_csv_train_batch(args: argparse.Namespace) -> None:
     from cointrainer.train.local_csv import (
         FEATURE_LIST,
         TrainConfig,
-        _dataset_fingerprint,
         _fit_model,
         _maybe_publish_registry,
         _save_local,
@@ -188,7 +188,14 @@ def _cmd_csv_train_batch(args: argparse.Namespace) -> None:
             f"gpu_platform_id={cfg.gpu_platform_id if cfg.gpu_platform_id is not None else -1} "
             f"gpu_device_id={cfg.gpu_device_id if cfg.gpu_device_id is not None else -1}"
         )
-        item = {"file": str(f), "symbol": symbol, "status": "ok", "model": None, "pointer": None, "error": None}
+        item = {
+            "file": str(f),
+            "symbol": symbol,
+            "status": "ok",
+            "model": None,
+            "pointer": None,
+            "error": None,
+        }
         try:
             if is_csv7(f):
                 train_from_csv7(f, cfg, limit_rows=args.limit_rows)
@@ -213,7 +220,9 @@ def _cmd_csv_train_batch(args: argparse.Namespace) -> None:
                 }
                 path = _save_local(model, cfg, meta)
                 try:
-                    import io, joblib
+                    import io
+
+                    import joblib
 
                     buf = io.BytesIO()
                     joblib.dump(model, buf)
@@ -238,13 +247,14 @@ def _cmd_csv_train_batch(args: argparse.Namespace) -> None:
             item["pointer"] = f"{prefix}/LATEST.json"
         summary.append(item)
         print(
-            f"[{item['status'].upper()}] {symbol} <- {f}  model={item['model']}  pointer={item['pointer'] or '-'}"
+            f"[{item['status'].upper()}] {symbol} <- {f}  "
+            f"model={item['model']}  pointer={item['pointer'] or '-'}"
         )
 
     (outdir / "batch_train_summary.json").write_text(json.dumps(summary, indent=2))
-    print(
-        f"\nBatch finished: {sum(s['status']=='ok' for s in summary)} ok / {len(summary) - sum(s['status']=='ok' for s in summary)} failed."
-    )
+    ok_count = sum(s["status"] == "ok" for s in summary)
+    fail_count = len(summary) - ok_count
+    print(f"\nBatch finished: {ok_count} ok / {fail_count} failed.")
     print(f"Summary: {outdir / 'batch_train_summary.json'}")
 
 
@@ -380,6 +390,41 @@ def main(argv: list[str] | None = None) -> None:
     csv_train_batch.add_argument("--n-jobs", type=int, default=None)
     csv_train_batch.set_defaults(func=_cmd_csv_train_batch)
 
+    op = sub.add_parser(
+        "optimize",
+        help="Search best training+backtest settings for a symbol on a CSV.",
+    )
+    op.add_argument("--file", required=True)
+    op.add_argument("--symbol", required=True)
+    op.add_argument("--horizons", nargs="+", type=int, default=[15, 30, 60])
+    op.add_argument(
+        "--holds",
+        nargs="+",
+        type=float,
+        default=[0.001, 0.0015, 0.002, 0.003],
+    )
+    op.add_argument(
+        "--open-thrs",
+        nargs="+",
+        type=float,
+        default=[0.52, 0.55, 0.58],
+    )
+    op.add_argument(
+        "--positions",
+        nargs="+",
+        default=["gated", "sized"],
+        choices=["gated", "sized"],
+    )
+    op.add_argument("--fee-bps", type=float, default=2.0)
+    op.add_argument("--slip-bps", type=float, default=0.0)
+    op.add_argument("--device-type", default="gpu", choices=["cpu", "gpu", "cuda"])
+    op.add_argument("--max-bin", type=int, default=63)
+    op.add_argument("--n-jobs", type=int, default=0)
+    op.add_argument("--limit-rows", type=int, default=None)
+    op.add_argument("--outdir", default="out/opt")
+    op.add_argument("--optuna", action="store_true", help="Use Optuna Bayesian search")
+    op.add_argument("--trials", type=int, default=30, help="Optuna trial count")
+
     # registry-smoke
     rs = sub.add_parser(
         "registry-smoke",
@@ -410,6 +455,34 @@ def main(argv: list[str] | None = None) -> None:
             print(version("cointrader-trainer"))
         except PackageNotFoundError:
             print("0.1.0")
+        return
+
+    if args.cmd == "optimize":
+        from pathlib import Path
+
+        from cointrainer.backtest.optimize import optimize_grid, optimize_optuna
+
+        fn = optimize_optuna if args.optuna else optimize_grid
+        kwargs = {
+            "csv_path": Path(args.file),
+            "symbol": args.symbol.upper(),
+            "horizons": args.horizons,
+            "holds": args.holds,
+            "open_thrs": args.open_thrs,
+            "position_modes": args.positions,
+            "fee_bps": args.fee_bps,
+            "slip_bps": args.slip_bps,
+            "device_type": args.device_type,
+            "max_bin": args.max_bin,
+            "n_jobs": args.n_jobs,
+            "limit_rows": args.limit_rows,
+            "outdir": Path(args.outdir),
+        }
+        if args.optuna:
+            kwargs["n_trials"] = args.trials
+        res = fn(**kwargs)
+        print("[optimize] best:", res["best"])
+        print("[optimize] leaderboard:", res["leaderboard"])
         return
 
     if args.cmd == "registry-smoke":


### PR DESCRIPTION
## Summary
- add grid and Optuna search utilities for training+backtest auto-optimization
- expose new `cointrainer optimize` CLI command for leaderboard generation
- implement simple CSV backtester for probability thresholds

## Testing
- `ruff check src/cointrainer/backtest/optimize.py src/cointrainer/backtest/run.py src/cointrainer/cli.py`
- `pytest` *(fails: KeyError: 'start', ValueError: CSV must contain unix/date timestamp and close columns, and other missing config errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e4228c0608330bae12f2897f2c4f4