### PR TITLE
Introduce RiskConfig with volatility horizon support

### DIFF
--- a/src/crypto_bot/__init__.py
+++ b/src/crypto_bot/__init__.py
@@ -1,5 +1,6 @@
 """Crypto bot package."""
 
+from .risk import RiskConfig
 from .version import MIN_CT2_INTEGRATION, __version__
 
-__all__ = ["MIN_CT2_INTEGRATION", "__version__"]
+__all__ = ["MIN_CT2_INTEGRATION", "RiskConfig", "__version__"]

--- a/src/crypto_bot/risk.py
+++ b/src/crypto_bot/risk.py
@@ -1,0 +1,42 @@
+"""Risk configuration models used by the trading bot.
+
+This module introduces :class:`RiskConfig` which mirrors the behaviour of
+runtime dataclasses used in the full coinTrader2.0 application. The primary
+motivation for adding this lightweight implementation is to avoid runtime
+failures when configuration files specify the ``vol_horizon_secs`` field. The
+previous implementation did not accept this argument and raised a ``TypeError``
+when the bot started.
+
+The class intentionally accepts arbitrary additional keyword arguments so that
+new configuration fields can be added without immediately requiring code
+changes in dependent projects. Unknown fields are stored on the ``extra``
+attribute for potential downstream use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass(init=False)
+class RiskConfig:
+    """Container for risk related settings.
+
+    Parameters
+    ----------
+    vol_horizon_secs:
+        Horizon in seconds used when computing volatility based risk limits.
+        Defaults to ``3600`` (one hour).
+    **kwargs:
+        Any additional keyword arguments are retained on :attr:`extra` so that
+        new configuration options do not break instantiation.
+    """
+
+    vol_horizon_secs: int = 3600
+    extra: dict[str, Any] = field(default_factory=dict, repr=False)
+
+    def __init__(self, vol_horizon_secs: int = 3600, **kwargs: Any) -> None:
+        self.vol_horizon_secs = vol_horizon_secs
+        # Preserve unknown arguments for forward compatibility
+        self.extra = dict(kwargs)

--- a/tests/test_risk_config.py
+++ b/tests/test_risk_config.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+# Ensure the src directory is on sys.path so that the ``crypto_bot`` package is
+# importable when tests are executed in isolation.
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from crypto_bot.risk import RiskConfig
+
+
+def test_risk_config_accepts_extra_fields():
+    cfg = RiskConfig(vol_horizon_secs=7200, max_drawdown=0.1)
+    assert cfg.vol_horizon_secs == 7200
+    assert cfg.extra["max_drawdown"] == 0.1


### PR DESCRIPTION
## Summary
- add lightweight `RiskConfig` dataclass that accepts `vol_horizon_secs` and ignores extra fields
- re-export `RiskConfig` from `crypto_bot` package for easier import
- test `RiskConfig` handles additional configuration values

## Testing
- `ruff check src/crypto_bot/risk.py src/crypto_bot/__init__.py tests/test_risk_config.py`
- `pytest tests/test_risk_config.py -q`
- `pytest -q` *(fails: KeyError: 'start', FileNotFoundError: cfg.yaml, and other environmental issues)*

------
https://chatgpt.com/codex/tasks/task_e_689e4e8043108330a115775b2b471989