### PR TITLE
test(optimize): optional Optuna tests

### DIFF
--- a/tests/test_optimize_availability.py
+++ b/tests/test_optimize_availability.py
@@ -1,0 +1,10 @@
+import importlib
+
+
+def test_optuna_optional():
+    try:
+        optuna = importlib.import_module("optuna")
+        assert optuna is not None
+    except Exception:
+        # It's okay if optuna isn't installed
+        assert True

--- a/tests/test_optimize_grid_fallback.py
+++ b/tests/test_optimize_grid_fallback.py
@@ -1,0 +1,57 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+from cointrainer.backtest.optimize import optimize_grid
+from cointrainer.backtest import run as bt_run
+
+
+class _DummyModel:
+    def predict_proba(self, X):
+        # return uniform probabilities for three classes
+        return np.ones((len(X), 3)) / 3
+
+
+def test_grid_optimizer_runs(tmp_path, monkeypatch):
+    # small synthetic normalized csv
+    idx = pd.date_range("2025-01-01", periods=5000, freq="T", tz="UTC")
+    price = 100 * (1 + 0.0005 * np.sin(np.arange(len(idx)) / 20)).cumprod()
+    df = pd.DataFrame(
+        {
+            "open": price,
+            "high": price * 1.0005,
+            "low": price * 0.9995,
+            "close": price,
+            "volume": np.random.randint(1, 5, size=len(idx)),
+            "trades": np.random.randint(1, 3, size=len(idx)),
+        },
+        index=idx,
+    )
+    p = tmp_path / "SYN_1m.normalized.csv"
+    df.to_csv(p, index=True)
+
+    # Patch model loading to avoid joblib dependency on a real model file
+    monkeypatch.setattr(bt_run, "load_model_local", lambda path: _DummyModel())
+
+    res = optimize_grid(
+        csv_path=p,
+        symbol="SYN",
+        horizons=[15],
+        holds=[0.0015],
+        open_thrs=[0.55],
+        position_modes=["gated"],
+        fee_bps=2.0,
+        slip_bps=0.0,
+        device_type="cpu",
+        max_bin=63,
+        n_jobs=0,
+        limit_rows=4000,
+        outdir=tmp_path,
+    )
+    assert "best" in res and "leaderboard" in res
+

--- a/tests/test_optuna_smoke.py
+++ b/tests/test_optuna_smoke.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+from pathlib import Path
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
+
+
+@pytest.mark.skipif(pytest.importorskip("optuna", reason="optuna not installed") is None, reason="no optuna")
+def test_optuna_smoke(tmp_path):
+    opt_mod = pytest.importorskip(
+        "cointrainer.backtest.optuna_opt", reason="optuna optimizer unavailable"
+    )
+    optimize_optuna = opt_mod.optimize_optuna
+    OptunaConfig = opt_mod.OptunaConfig
+    # tiny synthetic dataset
+    idx = pd.date_range("2025-01-01", periods=12000, freq="T", tz="UTC")
+    price = 100 * (1 + 0.0005 * np.sin(np.arange(len(idx)) / 20)).cumprod()
+    df = pd.DataFrame(
+        {
+            "open": price,
+            "high": price * 1.0005,
+            "low": price * 0.9995,
+            "close": price,
+            "volume": np.random.randint(1, 5, size=len(idx)),
+            "trades": 1,
+        },
+        index=idx,
+    )
+    p = tmp_path / "SYN_1m.normalized.csv"
+    df.to_csv(p)
+    cfg = OptunaConfig(
+        n_trials=2,
+        n_folds=2,
+        val_len=1000,
+        gap=10,
+        limit_rows=8000,
+        device_type="cpu",
+        max_bin=63,
+        n_jobs=0,
+    )
+    res = optimize_optuna(p, "SYN", outdir=tmp_path, cfg=cfg)
+    assert "best" in res
+


### PR DESCRIPTION
## Summary
- add availability test for Optuna as optional dependency
- verify grid optimizer fallback runs on synthetic data
- include Optuna smoke test that runs only when Optuna optimizer is available

## Testing
- `pytest tests/test_optimize_availability.py tests/test_optimize_grid_fallback.py tests/test_optuna_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e57dcf3b48330a4120f552705f346