### PR TITLE
Validate signals parameter in backtesting utilities

### DIFF
--- a/backtest.py
+++ b/backtest.py
@@ -28,14 +28,14 @@ class CryptoStrategy(bt.Strategy):
 
     Parameters
     ----------
-    signals : Iterable[int | float]
+    signals : Iterable[int | float], optional
         Sequence of trading signals aligned with the data feed. ``1``
         represents a long position, ``-1`` a short position and ``0``
-        means flat. This parameter is required and must not be
-        ``None``.
+        means flat. Defaults to an empty list. Passing ``None`` will
+        raise a :class:`ValueError`.
     """
 
-    params: ClassVar[dict[str, Any]] = {"signals": None}
+    params: ClassVar[dict[str, Any]] = {"signals": []}
 
     def __init__(self) -> None:
         if self.params.signals is None:
@@ -83,7 +83,8 @@ def run_backtest(
     signals : Iterable[int | float]
         Sequence of trade signals aligned to ``df``. ``1`` represents a
         long position, ``-1`` a short position and ``0`` flat. This
-        parameter is required and must not be ``None``.
+        parameter is required and must not be ``None``; passing ``None``
+        raises :class:`ValueError`.
     slippage : float, optional
         Percentage slippage applied to trades. Defaults to ``0.005``.
     costs : float, optional
@@ -95,6 +96,10 @@ def run_backtest(
         Dictionary including at least ``'start_value'`` and
         ``'final_value'`` of the portfolio.
     """
+
+    if signals is None:
+        msg = "signals parameter is required"
+        raise ValueError(msg)
 
     cerebro = bt.Cerebro()
     data = bt.feeds.PandasData(dataname=df)

--- a/src/cointrainer/evaluation.py
+++ b/src/cointrainer/evaluation.py
@@ -162,7 +162,16 @@ def run_backtest(
     import backtrader as bt
 
     class _SignalStrategy(bt.Strategy):
-        params: ClassVar[dict[str, Any]] = {"signals": None}
+        """Backtrader strategy executing precomputed signals.
+
+        Parameters
+        ----------
+        signals : Iterable[int | float], optional
+            Sequence of trading signals aligned to the data feed. Defaults
+            to an empty list. Passing ``None`` raises :class:`ValueError`.
+        """
+
+        params: ClassVar[dict[str, Any]] = {"signals": []}
 
         def __init__(self):
             if self.p.signals is None:

--- a/tests/test_backtest.py
+++ b/tests/test_backtest.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import pandas as pd
+import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -28,4 +29,20 @@ def test_run_backtest_simple():
     assert "final_value" in stats
     assert isinstance(stats["final_value"], float)
     assert stats["final_value"] > 0
+
+
+def test_run_backtest_requires_signals():
+    df = pd.DataFrame(
+        {
+            "open": [1.0, 1.1, 1.2],
+            "high": [1.0, 1.1, 1.2],
+            "low": [1.0, 1.1, 1.2],
+            "close": [1.0, 1.1, 1.2],
+            "volume": [1, 1, 1],
+        },
+        index=pd.date_range("2021-01-01", periods=3, freq="D"),
+    )
+
+    with pytest.raises(ValueError, match="signals parameter is required"):
+        run_backtest(df, None)
 


### PR DESCRIPTION
## Summary
- ensure `CryptoStrategy` and evaluation backtests default `signals` to an empty list
- raise `ValueError` when `signals` is `None` in both strategy classes and helper
- document new default behavior
- add test covering missing `signals`

## Testing
- `pytest tests/test_backtest.py -q`
- `PYTHONPATH=src pytest tests/test_evaluation.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689e5bb7ab64833087af1a73e44c9324