### PR TITLE
feat: add csv-train-aggregate CLI command

### DIFF
--- a/tests/test_cli_aggregate_help.py
+++ b/tests/test_cli_aggregate_help.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+
+def test_cli_help_has_aggregate():
+    result = subprocess.run(
+        [sys.executable, "-m", "cointrainer.cli", "--help"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT)},
+    )
+    assert result.returncode == 0
+    assert "csv-train-aggregate" in result.stdout


### PR DESCRIPTION
## Summary
- add `csv-train-aggregate` subcommand for aggregated training of regime models
- include documentation and arguments for global vs per-pair model training
- cover CLI help with tests

## Testing
- `pytest tests/test_cli_aggregate_help.py tests/test_cli_help.py tests/test_cli_batch_help.py tests/test_cli_csv7_help.py -q`
- `ruff check src/cointrainer/cli.py tests/test_cli_aggregate_help.py`


------
https://chatgpt.com/codex/tasks/task_e_68a0e145d7f083308792a0dcf1d569d3