### PR TITLE
Add aggregate training CLI and pair slug tests

### DIFF
--- a/src/cointrainer/cli.py
+++ b/src/cointrainer/cli.py
@@ -258,6 +258,31 @@ def _cmd_csv_train_batch(args: argparse.Namespace) -> None:
     print(f"Summary: {outdir / 'batch_train_summary.json'}")
 
 
+def _cmd_csv_train_aggregate(args: argparse.Namespace) -> None:
+    from cointrainer.train.global_model import GlobalTrainConfig, train_aggregate
+
+    cfg = GlobalTrainConfig(
+        horizon=args.horizon,
+        hold=args.hold,
+        outdir=Path(args.outdir),
+        publish_to_registry=args.publish,
+        global_symbol=args.global_symbol,
+        per_pair=args.per_pair,
+        limit_rows_per_file=args.limit_rows_per_file,
+        cap_rows_per_pair=args.cap_rows_per_pair,
+        max_total_rows=args.max_total_rows,
+        downsample_flat=args.downsample_flat,
+        device_type=args.device_type,
+        gpu_platform_id=args.gpu_platform_id,
+        gpu_device_id=args.gpu_device_id,
+        max_bin=args.max_bin,
+        gpu_use_dp=args.gpu_use_dp,
+        n_jobs=args.n_jobs,
+        random_state=args.random_state,
+    )
+    train_aggregate(Path(args.folder), args.glob, args.recursive, cfg)
+
+
 def main(argv: list[str] | None = None) -> None:
     parser = argparse.ArgumentParser(prog="cointrainer")
     parser.add_argument("--version", action="store_true", help="Show version and exit")
@@ -390,6 +415,64 @@ def main(argv: list[str] | None = None) -> None:
     csv_train_batch.add_argument("--n-jobs", type=int, default=None)
     csv_train_batch.set_defaults(func=_cmd_csv_train_batch)
 
+    csv_train_agg = sub.add_parser(
+        "csv-train-aggregate",
+        help="Aggregate many CSVs into one training run (global or per-pair).",
+    )
+    csv_train_agg.add_argument(
+        "--folder", required=True, help="Folder containing CSV files"
+    )
+    csv_train_agg.add_argument(
+        "--glob", default="*.csv", help="Glob pattern (default: *.csv)"
+    )
+    csv_train_agg.add_argument(
+        "--recursive", action="store_true", help="Recurse into subfolders"
+    )
+    csv_train_agg.add_argument(
+        "--per-pair", action="store_true", help="Train one model per pair"
+    )
+    csv_train_agg.add_argument(
+        "--global-symbol", default="GLOBAL", help="Symbol for global model"
+    )
+    csv_train_agg.add_argument(
+        "--limit-rows-per-file", type=int, default=None,
+        help="Tail rows per file (optional)",
+    )
+    csv_train_agg.add_argument(
+        "--cap-rows-per-pair", type=int, default=None,
+        help="Cap rows per pair (optional)",
+    )
+    csv_train_agg.add_argument(
+        "--max-total-rows", type=int, default=None,
+        help="Max total rows across all files",
+    )
+    csv_train_agg.add_argument(
+        "--downsample-flat", type=float, default=None,
+        help="Fraction of y==0 rows to keep",
+    )
+    csv_train_agg.add_argument(
+        "--horizon", type=int, default=15, help="Label horizon in bars"
+    )
+    csv_train_agg.add_argument(
+        "--hold", type=float, default=0.0015, help="Hold band (e.g., 0.0015)"
+    )
+    csv_train_agg.add_argument(
+        "--publish", action="store_true", help="Publish to registry if configured"
+    )
+    csv_train_agg.add_argument(
+        "--outdir", default="local_models", help="Where to write model(s)"
+    )
+    csv_train_agg.add_argument(
+        "--device-type", default="gpu", choices=["cpu", "gpu", "cuda"]
+    )
+    csv_train_agg.add_argument("--gpu-platform-id", type=int, default=None)
+    csv_train_agg.add_argument("--gpu-device-id", type=int, default=None)
+    csv_train_agg.add_argument("--max-bin", type=int, default=63)
+    csv_train_agg.add_argument("--gpu-use-dp", action="store_true")
+    csv_train_agg.add_argument("--n-jobs", type=int, default=0)
+    csv_train_agg.add_argument("--random-state", type=int, default=42)
+    csv_train_agg.set_defaults(func=_cmd_csv_train_aggregate)
+
     ab = sub.add_parser(
         "autobacktest",
         help="Continuous loop: retrain+backtest on updates, optional publish.",
@@ -443,7 +526,11 @@ def main(argv: list[str] | None = None) -> None:
     bt.add_argument("--file", required=True)
     bt.add_argument("--symbol", required=True)
     bt.add_argument("--model", default=None, help="Path to local .pkl model")
-    bt.add_argument("--from-registry", action="store_true", help="Load model from Supabase (LATEST.json)")
+    bt.add_argument(
+        "--from-registry",
+        action="store_true",
+        help="Load model from Supabase (LATEST.json)",
+    )
     bt.add_argument("--open-thr", type=float, default=0.55)
     bt.add_argument("--close-thr", type=float, default=None)
     bt.add_argument("--fee-bps", type=float, default=2.0)
@@ -486,8 +573,9 @@ def main(argv: list[str] | None = None) -> None:
         return
 
     if args.cmd == "autobacktest":
-        from cointrainer.backtest.continuous import loop_autobacktest
         from pathlib import Path
+
+        from cointrainer.backtest.continuous import loop_autobacktest
 
         loop_autobacktest(
             csv_path=Path(args.file),
@@ -508,12 +596,12 @@ def main(argv: list[str] | None = None) -> None:
     if args.cmd == "optimize":
         from pathlib import Path
 
+        from cointrainer.backtest.optimize import optimize_grid
         from cointrainer.backtest.optuna_opt import (
             OptunaConfig,
             optimize_optuna,
             publish_best_model,
         )
-        from cointrainer.backtest.optimize import optimize_grid
 
         csv_path = Path(args.file)
         symbol = args.symbol.upper()
@@ -544,7 +632,7 @@ def main(argv: list[str] | None = None) -> None:
                 key = publish_best_model(csv_path, symbol, outdir, res["best"])
                 print(f"[optimize] Published best model to: {key}")
             return
-        except RuntimeError as e:
+        except RuntimeError:
             print("[optimize] Optuna not available → falling back to grid search")
             res = optimize_grid(
                 csv_path=csv_path,
@@ -565,8 +653,9 @@ def main(argv: list[str] | None = None) -> None:
             print("[optimize-grid] leaderboard:", res["leaderboard"])
             return
     if args.cmd == "backtest":
-        from cointrainer.backtest.run import backtest_csv
         from pathlib import Path
+
+        from cointrainer.backtest.run import backtest_csv
         prefix = None
         if args.from_registry:
             prefix = f"models/regime/{args.symbol.upper()}"

--- a/tests/test_cli_aggregate_help.py
+++ b/tests/test_cli_aggregate_help.py
@@ -1,0 +1,16 @@
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1] / "src"
+
+def test_cli_has_csv_train_aggregate():
+    out = subprocess.run(
+        [sys.executable, "-m", "cointrainer.cli", "--help"],
+        capture_output=True,
+        text=True,
+        env={**os.environ, "PYTHONPATH": str(ROOT)},
+    )
+    assert out.returncode == 0
+    assert "csv-train-aggregate" in out.stdout

--- a/tests/test_pairs_slug.py
+++ b/tests/test_pairs_slug.py
@@ -1,0 +1,12 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from cointrainer.utils.pairs import canonical_pair_from_filename, slug_from_canonical
+
+
+def test_pair_slug_utils():
+    assert canonical_pair_from_filename("BTCUSDT_1m.csv") == "BTCUSDT"
+    s = slug_from_canonical("BTCUSDT")
+    assert s in ("BTC-USDT", "BTC-USD", "BTC-USDT")  # tolerate quote variants


### PR DESCRIPTION
## Summary
- add csv-train-aggregate command to CLI for global or per-pair LightGBM training
- add tests for CLI aggregate help and pair slug utilities

## Testing
- `ruff check tests/test_cli_aggregate_help.py tests/test_pairs_slug.py src/cointrainer/cli.py`
- `pytest tests/test_cli_aggregate_help.py tests/test_pairs_slug.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1523d5883308225afcaa4cead55